### PR TITLE
Repository languages tags links to language page

### DIFF
--- a/src/client/App/App.js
+++ b/src/client/App/App.js
@@ -4,6 +4,7 @@ import About from '~/pages/about/About'
 import NavBar from '~/components/nav-bar/NavBar'
 import Developers from '~/pages/developers/Developers'
 import Repositories from '~/pages/repositories/Repositories'
+import Languages from '~/pages/languages/Languages'
 import FloatingButton from '~/components/floating-button/FloatingButton'
 import PageViewTracker from '~/components/page-view-tracker/PageViewTracker'
 
@@ -16,6 +17,7 @@ const App = () => (
       <NavBar/>
       <div className="container">
         <Route exact path="/" render={() => <Redirect to="/repositories" />} />
+        <Route path="/languages" component={Languages} />
         <Route path="/repositories" component={Repositories} />
         <Route path="/developers" component={Developers} />
         <Route path="/about" component={About} />

--- a/src/client/components/repository-list/repository-card/RepositoryCard.js
+++ b/src/client/components/repository-list/repository-card/RepositoryCard.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import { OutboundLink } from 'react-ga'
 
 const style = {
@@ -49,8 +50,17 @@ const RepositoryCard = ({repo}) => {
       </div>
       <div className="card-action" style={style.languages}>
         {repo.languages.length === 0
-          ? <span style={style.language}>(no languages)</span>
-          : repo.languages.map((lang, index) => <span key={index} className={lang.color} style={style.language}>{lang.name}</span>)
+          ? '(no languages)'
+          : repo.languages.map((lang, index) =>  {
+            return <Link
+              style={style.language}
+              to={`/languages/${ lang.name }`}
+              className={lang.color}
+              key={`${repo.id}-${lang.name}`}
+            >
+              {lang.name}
+            </Link>
+          })
         }
       </div>
       <div className="card-action truncate" style={style.cardAction}>

--- a/src/client/pages/language-repositories/LanguageRepositories.js
+++ b/src/client/pages/language-repositories/LanguageRepositories.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import DocumentTitle from 'react-document-title'
+import { orderBy, each, filter, includes } from 'lodash'
+import utils from '~/utils'
+import store from '~/store/store'
+import Loading from '~/components/loading/Loading'
+import RepositoryList from '~/components/repository-list/RepositoryList'
+
+class LanguageRepositories extends React.Component {
+  constructor(props) {
+    super(props)
+    let languageName = this._parseLanguageParam(props)
+    this.state = {
+      languageName: languageName,
+      repos: [],
+      loading: true,
+      error: false
+    }
+  }
+
+  _parseLanguageParam(props) {
+    return props.match.params.language
+  }
+
+  _getRepos = (languageName) => {
+    store.getRepos().then((response) => {
+      let orderedRepos = orderBy(response.items, ['stargazers', 'forks', 'watchers', 'name'], ['desc', 'desc', 'desc', 'asc'])
+      .filter(function(repo) {
+        return repo.languages.map(function(l) { return l.name }).includes(languageName);
+      })
+      each(orderedRepos, (repo, index) => repo.position = index + 1)
+      this.setState({
+        languageName: languageName,
+        repos: orderedRepos,
+        loading: !response.ready,
+        error: response.error,
+        key: Math.random()
+      })
+    })
+  }
+
+  componentDidMount() {
+    this._getRepos(this.state.languageName)
+  }
+
+  componentWillReceiveProps(newProps) {
+    let oldLanguage = this._parseLanguageParam(this.props)
+    let language = this._parseLanguageParam(newProps)
+
+    if(oldLanguage !== language) {
+      this._getRepos(language)
+    }
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <Loading />
+    }
+
+    return (
+      <DocumentTitle title={`${this.state.languageName} repositories – Dominican Open Source`}>
+        <RepositoryList repos={this.state.repos} key={this.state.key} />
+      </DocumentTitle>
+    )
+  }
+}
+
+export default LanguageRepositories

--- a/src/client/pages/languages/Languages.js
+++ b/src/client/pages/languages/Languages.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Route, Redirect, NavLink } from 'react-router-dom'
+import LanguageRepositories from '~/pages/language-repositories/LanguageRepositories'
+
+const Languages = (props) => (
+  <div>
+    <Route path="/languages/:language" component={LanguageRepositories} />
+    <Route exact path="/languages" render={() => <Redirect to="/repositories/popular" />} />
+  </div>
+)
+
+export default Languages;


### PR DESCRIPTION
About #69, I agree that language tag names should be clickable.

This pull request introduces the `Languages` page and the `LanguagesRepositories` component that filters repositories using the `:language` Route param.

This fixes closes #69.

