### PR TITLE
add comma separator to page title counts

### DIFF
--- a/src/client/pages/new-repositories/NewRepositories.js
+++ b/src/client/pages/new-repositories/NewRepositories.js
@@ -51,7 +51,7 @@ class NewRepositories extends React.Component {
         <DocumentTitle title="New Repositories – Dominican Open Source">
           <div>
             <h3 className="center-align">New repositories</h3>
-            <p className="center-align">Showing <strong>{ newRepos.length }</strong> repositories <em>created in the last 7 days</em>.</p>
+            <p className="center-align">Showing <strong>{ newRepos.length.toLocaleString() }</strong> repositories <em>created in the last 7 days</em>.</p>
             <RepositoryList repos={newRepos} />
           </div>
         </DocumentTitle>

--- a/src/client/pages/popular-developers/PopularDevelopers.js
+++ b/src/client/pages/popular-developers/PopularDevelopers.js
@@ -35,7 +35,7 @@ class PopularDevelopers extends React.Component {
       <DocumentTitle title="Popular Developers – Dominican Open Source">
         <div>
           <h3 className="center-align">Popular developers</h3>
-          <p className="center-align">Showing <strong>{ users.length }</strong> developers <em>sorted by followers</em>.</p>
+          <p className="center-align">Showing <strong>{ users.length.toLocaleString() }</strong> developers <em>sorted by followers</em>.</p>
           <DeveloperList users={ users } />
         </div>
       </DocumentTitle>

--- a/src/client/pages/popular-repositories/PopularRepositories.js
+++ b/src/client/pages/popular-repositories/PopularRepositories.js
@@ -47,7 +47,7 @@ class PopularRepositories extends React.Component {
       <DocumentTitle title="Popular Repositories – Dominican Open Source">
         <div>
           <h3 className="center-align">Popular repositories</h3>
-          <p className="center-align">Showing <strong>{ repos.length }</strong> repositories <em>sorted by stars</em>.</p>
+          <p className="center-align">Showing <strong>{ repos.length.toLocaleString() }</strong> repositories <em>sorted by stars</em>.</p>
           <RepositoryList repos={repos} />
         </div>
       </DocumentTitle>

--- a/src/client/pages/recently-joined-developers/RecentlyJoinedDevelopers.js
+++ b/src/client/pages/recently-joined-developers/RecentlyJoinedDevelopers.js
@@ -39,7 +39,7 @@ class RecentlyJoinedDevelopers extends React.Component {
       <DocumentTitle title="Recently Joined Developers – Dominican Open Source">
         <div>
           <h3 className="center-align">Recently joined developers</h3>
-          <p className="center-align">Showing <strong>{ newUsers.length }</strong> developers that <em>has joined in the last 30 days</em>.</p>
+          <p className="center-align">Showing <strong>{ newUsers.length.toLocaleString() }</strong> developers that <em>has joined in the last 30 days</em>.</p>
           <DeveloperList users={ newUsers } />
         </div>
       </DocumentTitle>

--- a/src/client/pages/repositories-by-language/RepositoriesByLanguage.js
+++ b/src/client/pages/repositories-by-language/RepositoriesByLanguage.js
@@ -50,7 +50,7 @@ class RepositoriesByLanguage extends React.Component {
       <DocumentTitle title={ `Popular ${language} repositories – Dominican Open Source` }>
         <div>
           <h3 className="center-align">Popular <u>{ language }</u> repositories</h3>
-          <p className="center-align">Showing <strong>{ filteredRepos.length }</strong> repositories.</p>
+          <p className="center-align">Showing <strong>{ filteredRepos.length.toLocaleString() }</strong> repositories.</p>
           <RepositoryList repos={ filteredRepos } />
         </div>
       </DocumentTitle>


### PR DESCRIPTION
Closes #102 

Adds a comma separator to the counts on the top of each repository or developer list pages.

<img width="921" alt="screen shot 2017-11-26 at 18 06 57" src="https://user-images.githubusercontent.com/8761/33244827-a6580296-d2d4-11e7-8b0b-4c721fe34325.png">
