### PR TITLE
Enabled sidenav toggle

### DIFF
--- a/src/client/components/nav-bar/NavBar.js
+++ b/src/client/components/nav-bar/NavBar.js
@@ -23,6 +23,15 @@ class NavBar extends React.Component {
   componentDidMount() {
     const sidenav = document.querySelector('.side-nav')
     M.Sidenav.init(sidenav, {closeOnClick: true})
+   
+    this.initSidenavOverlay()
+  }
+
+  initSidenavOverlay(){
+    const sidenavOverlay = document.querySelector('.sidenav-overlay')
+    sidenavOverlay.setAttribute('id', 'sidenav-overlay')
+    sidenavOverlay.style.opacity = 0
+    sidenavOverlay.style.display = 'none'
   }
 
   render() {


### PR DESCRIPTION
Enabled  the sidenav toggle by adding the corresponding ID to the overlay DOM element at run-time and the missing CSS properties in order to match the current Bulma's CSS.