### PR TITLE
Fix in searchRepos query

### DIFF
--- a/src/server/services/github/queries/index.js
+++ b/src/server/services/github/queries/index.js
@@ -48,6 +48,7 @@ module.exports = {
         repositoryCount
         nodes {
           ... on Repository {
+            __typename
             id
             name: nameWithOwner
             description


### PR DESCRIPTION
The repo data is not updated due to validation after calling `searchRepos` query,

```
    response.search.nodes = response.search.nodes.filter((node) => {
      return node.__typename === 'Repository' && !node.isPrivate
    })
```

Today, the query result doesn't return the property `__typename`, therefore the return value of the filter is always `false`. I modified the query to be able to return the `__typename`.